### PR TITLE
Add compatibility with CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(qhotkey
     VERSION 1.5.0


### PR DESCRIPTION
Starting at CMake 4.0, the minimum required policy version is 3.5.0[1], either specified by 'cmake_minimum_required()' or by 'cmake_policy()'. This also applies to individual policies when they are set, which must match 3.5.0 or later policies.

[1] https://cmake.org/cmake/help/v4.0/command/cmake_minimum_required.html